### PR TITLE
Adapt to use getReferencedViewPConnect(true)

### DIFF
--- a/src/components/Assignment/index.ts
+++ b/src/components/Assignment/index.ts
@@ -192,7 +192,7 @@ class Assignment extends BridgeBase {
       const childPConn = child.getPConnect();
       const childType = childPConn.getComponentName();
       if (childType === "reference") {
-        dereferencedChildren.push(childPConn.getReferencedViewPConnect());
+        dereferencedChildren.push(childPConn.getReferencedViewPConnect(true));
       } else {
         // Not a reference so pass it through as it is
         dereferencedChildren.push(child);

--- a/src/components/DeferLoad/index.ts
+++ b/src/components/DeferLoad/index.ts
@@ -148,7 +148,7 @@ class DeferLoad extends BridgeBase {
           //  see one of those, update loadedPConn and componentName to be the
           //  referenced View, not the Reference component itself
           if (this.componentName === "reference") {
-            this.loadedPConn = this.loadedPConn.getReferencedViewPConnect().getPConnect();
+            this.loadedPConn = this.loadedPConn.getReferencedViewPConnect(true).getPConnect();
             this.componentName = "View";
           }
         }).then(() => {

--- a/src/components/ModalViewContainer/index.ts
+++ b/src/components/ModalViewContainer/index.ts
@@ -225,14 +225,14 @@ class ModalViewContainer extends BridgeBase {
                 //  So, we need to get referenced View PConnect and get its children
                 //  and CANNOT use the simpler, getReferencedView().children
 
-                const referencedViewPConn = newComp.getReferencedViewPConnect();
+                const referencedViewPConn = newComp.getReferencedViewPConnect(true);
                 // children needs to be an array!
                 this.arNewChildren = [ referencedViewPConn ];
 
                 // This approach below works, too. But it seems less clean to skip over
                 //  the Reference component like we do here. So, unless problems
                 //  are seen, using the approach above instead of this.
-                // const referencedChildren = newComp.getReferencedViewPConnect().getPConnect().getChildren();
+                // const referencedChildren = newComp.getReferencedViewPConnect(true).getPConnect().getChildren();
                 // this.arNewChildren = referencedChildren;
 
 


### PR DESCRIPTION
This forces "options" (ex: hasForm: true) to be put into the PConnect.