### PR TITLE
Coerce 2 digit month/day and 4 digit year

### DIFF
--- a/tests/common.js
+++ b/tests/common.js
@@ -15,7 +15,8 @@ const getNextDay = () => {
   const tomorrow = new Date();
   // add 1 day to today
   tomorrow.setDate(new Date().getDate() + 1);
-  return tomorrow.toLocaleString().split(",")[0];
+  // Need to get leading zeroes on single digit months and 4 digit year
+  return tomorrow.toLocaleDateString("en-US", {month: "2-digit", day: "2-digit", year: "numeric"});
 };
 
 module.exports = {


### PR DESCRIPTION
I've been seeing instances where the Service Date smoke test is failing seemingly because either the leading zeroes on the date aren't being typed. So, I'm tightening up the getNextDay code to force a 2-digit month and day and a 4 digit year.