### PR TITLE
Update default Const files to 8.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -406,9 +406,9 @@
       }
     },
     "@pega/constellationjs": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@pega/constellationjs/-/constellationjs-1.0.8.tgz",
-      "integrity": "sha512-ql6ufVMlIxG8D3spJmktDKXASJ4Lf8vtn167zV5UpFNKwl1v1GtCAtI2WNa4yyLJwyMF7szhD73B58L4GnW5sg=="
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@pega/constellationjs/-/constellationjs-1.0.15.tgz",
+      "integrity": "sha512-aMtsBfwolMUITkPjFer6v6rbg61s80K5yb3inyw2ylRrGh+iAwhc9UcxZsIlYGusMoL1lE64QEa4CoCZdpo0eg=="
     },
     "@polymer/iron-flex-layout": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@lion/radio-group": "^0.15.1",
     "@lion/select": "^0.11.1",
     "@lion/textarea": "^0.11.0",
-    "@pega/constellationjs": "SDK-8.6.4",
+    "@pega/constellationjs": "SDK-8.6.5",
     "@vaadin/router": "^1.7.4",
     "@vaadin/vaadin-grid": "^6.0.1",
     "@vaadin/vaadin-text-field": "^2.8.2",


### PR DESCRIPTION
With publication of 8.6.5 ConstellationJS files via npm, update the default for release/8.6