### PR TITLE
Update compareSdkPCoreVersions warning

### DIFF
--- a/src/helpers/versionHelpers.ts
+++ b/src/helpers/versionHelpers.ts
@@ -11,15 +11,10 @@
  
  export function compareSdkPCoreVersions() {
  
-   const theConstellationVersion = PCore.getPCoreVersion();
+  //  const theConstellationVersion = PCore.getPCoreVersion();
  
-   if (theConstellationVersion.includes(sdkVersion)) {
-     // eslint-disable-next-line no-console
-     console.log(`sdkVersion: ${sdkVersion} matches PCore version: ${PCore.getPCoreVersion()}`);
-   } else {
-     // eslint-disable-next-line no-console
-     console.error(`sdkVersion: ${sdkVersion} does NOT match PCore version: ${PCore.getPCoreVersion()}`);
-   }
+  // eslint-disable-next-line no-console
+  console.warn(`Using PCore version: ${PCore.getPCoreVersion()}. Confirm this is the same version as your Infinity server.`);
  
  }
  

--- a/src/helpers/versionHelpers.ts
+++ b/src/helpers/versionHelpers.ts
@@ -14,7 +14,6 @@
   //  const theConstellationVersion = PCore.getPCoreVersion();
  
   // eslint-disable-next-line no-console
-  console.warn(`Using PCore version: ${PCore.getPCoreVersion()}. Confirm this is the same version as your Infinity server.`);
- 
+  console.warn(`Using Constellation version ${PCore.getPCoreVersion()}. Ensure this is the same version as your Infinity server.`); 
  }
  


### PR DESCRIPTION
Updating message to align with changes made earlier to React SDK. Now, a warning since it isn't necessarily an error; just a troubleshooting tip.