### PR TITLE
fix: handled visibility prop in reference component

### DIFF
--- a/src/components/Reference/index.ts
+++ b/src/components/Reference/index.ts
@@ -157,6 +157,8 @@ class Reference extends BridgeBase {
   }
 
   render(){
+    if (this.resolvedConfigProps['visibility'] === false) return null;
+
     if (this.bLogging) { console.log(`${this.theComponentName}: render with pConn: ${JSON.stringify(this.pConn)}`); }
     if (this.bDebug){ debugger; }
 


### PR DESCRIPTION
visibility check handled in the reference component.

Current behavior: when opening embedded data flow in complex fields in DigV2 app, all the components are getting rendered by default regardless of visibility condition.

Expected behavior: Only selected components get displayed based on the options selected.