### PR TITLE
Properly use SDK Static Content Server for SDK static content

### DIFF
--- a/src/components/FlowContainer/index.ts
+++ b/src/components/FlowContainer/index.ts
@@ -292,7 +292,7 @@ class FlowContainer extends BridgeBase {
         "assignmentFinished");
 
       
-      this.checkSvg = Utils.getImageSrc("check", PCore.getAssetLoader().getStaticServerUrl());
+      this.checkSvg = Utils.getImageSrc("check", Utils.getSDKStaticContentUrl());
       return;
     }
     else {

--- a/src/components/NavBar/index.ts
+++ b/src/components/NavBar/index.ts
@@ -65,15 +65,15 @@ class NavBar extends BridgeBase {
 
 
     // was "assets" in Angular SDK ; is "static" in React
-    this.navIcon = Utils.getIconPath(PCore.getAssetLoader().getStaticServerUrl()).concat("pzpega-logo-mark.svg");
-    this.navExpandCollapse = Utils.getImageSrc("plus", PCore.getAssetLoader().getStaticServerUrl());
+    this.navIcon = Utils.getIconPath(Utils.getSDKStaticContentUrl()).concat("pzpega-logo-mark.svg");
+    this.navExpandCollapse = Utils.getImageSrc("plus", Utils.getSDKStaticContentUrl());
 
     // making a copy, so can add info
     this.navPages = JSON.parse(JSON.stringify(this.pages));
 
     for (let page in this.navPages) {
       //this.navPages$[page]["iconName"] = this.translateIcon(this.navPages$[page]["pxPageViewIcon"]);
-      this.navPages[page]["iconName"] = Utils.getImageSrc(this.navPages[page]["pxPageViewIcon"], PCore.getAssetLoader().getStaticServerUrl());
+      this.navPages[page]["iconName"] = Utils.getImageSrc(this.navPages[page]["pxPageViewIcon"], Utils.getSDKStaticContentUrl());
     }
 
 
@@ -83,7 +83,7 @@ class NavBar extends BridgeBase {
 //    this.logout = this.actionsAPI.logout.bind(this.actionsAPI);
 
     // was "assets" in Angular SDK ; is "static" in React
-    this.portalLogoImage = Utils.getIconPath(PCore.getAssetLoader().getStaticServerUrl()).concat("pzpega-logo-mark.svg");
+    this.portalLogoImage = Utils.getIconPath(Utils.getSDKStaticContentUrl()).concat("pzpega-logo-mark.svg");
     //this.portalOperator$ = oData["pxRequestor"].pxUserName;
     //this.portalOperator$ = oData["D_pxEnvironmentInfo"].pxOperator.pyUserName;
     this.portalOperator = PCore.getEnvironmentInfo().getOperatorName();
@@ -150,11 +150,11 @@ class NavBar extends BridgeBase {
   navPanelCreateButtonClick() {
 
     if (this.navExpandCollapse.indexOf("plus") > 0) {
-     this.navExpandCollapse = Utils.getImageSrc("times", PCore.getAssetLoader().getStaticServerUrl());
+     this.navExpandCollapse = Utils.getImageSrc("times", Utils.getSDKStaticContentUrl());
      this.bShowCaseTypes = true;
     }
     else {
-      this.navExpandCollapse = Utils.getImageSrc("plus", PCore.getAssetLoader().getStaticServerUrl());
+      this.navExpandCollapse = Utils.getImageSrc("plus", Utils.getSDKStaticContentUrl());
       this.bShowCaseTypes = false;
     }
 

--- a/src/components/Stages/index.ts
+++ b/src/components/Stages/index.ts
@@ -40,8 +40,8 @@ class Stages extends BridgeBase {
     //NOTE: Need to bind the callback to 'this' so it has this element's context when it's called.
     this.registerAndSubscribeComponent(this.onStateChange.bind(this));
 
-    this.imagePath = Utils.getIconPath(PCore.getAssetLoader().getStaticServerUrl());
-    this.checkSvgIcon = Utils.getImageSrc("check", PCore.getAssetLoader().getStaticServerUrl());
+    this.imagePath = Utils.getIconPath(Utils.getSDKStaticContentUrl());
+    this.checkSvgIcon = Utils.getImageSrc("check", Utils.getSDKStaticContentUrl());
     
   }
 

--- a/src/components/designSystemExtension/FieldGroupList/index.ts
+++ b/src/components/designSystemExtension/FieldGroupList/index.ts
@@ -18,7 +18,7 @@ class FieldGroupList extends LitElement {
   connectedCallback() {
     super.connectedCallback();
 
-    this.menuIconDelete = Utils.getImageSrc("trash", PCore.getAssetLoader().getStaticServerUrl());
+    this.menuIconDelete = Utils.getImageSrc("trash", Utils.getSDKStaticContentUrl());
   }
 
   disconnectedCallback() {

--- a/src/components/designSystemExtension/ListUtility/index.ts
+++ b/src/components/designSystemExtension/ListUtility/index.ts
@@ -53,10 +53,10 @@ class ListUtility extends LitElement {
   connectedCallback() {
     super.connectedCallback();
 
-    this.imagePath = Utils.getIconPath(PCore.getAssetLoader().getStaticServerUrl());
+    this.imagePath = Utils.getIconPath(Utils.getSDKStaticContentUrl());
 
-    this.headerSvgIcon = Utils.getImageSrc(this.icon, PCore.getAssetLoader().getStaticServerUrl());
-    this.settingsSvgIcon = Utils.getImageSrc("more", PCore.getAssetLoader().getStaticServerUrl());
+    this.headerSvgIcon = Utils.getImageSrc(this.icon, Utils.getSDKStaticContentUrl());
+    this.settingsSvgIcon = Utils.getImageSrc("more", Utils.getSDKStaticContentUrl());
     
   }
 

--- a/src/components/designSystemExtension/SummaryItem/index.ts
+++ b/src/components/designSystemExtension/SummaryItem/index.ts
@@ -44,12 +44,12 @@ class SummaryItem extends LitElement {
     super.connectedCallback();
 
 
-    this.imagePath = Utils.getIconPath(PCore.getAssetLoader().getStaticServerUrl());
+    this.imagePath = Utils.getIconPath(Utils.getSDKStaticContentUrl());
 
 
-    this.settingsSvgIcon = Utils.getImageSrc("more", PCore.getAssetLoader().getStaticServerUrl());
+    this.settingsSvgIcon = Utils.getImageSrc("more", Utils.getSDKStaticContentUrl());
     if (this.menuIconOverride != "") {
-      this.menuIconOverride = Utils.getImageSrc(this.menuIconOverride , PCore.getAssetLoader().getStaticServerUrl());
+      this.menuIconOverride = Utils.getImageSrc(this.menuIconOverride , Utils.getSDKStaticContentUrl());
     }
 
 

--- a/src/components/templates/CaseView/index.ts
+++ b/src/components/templates/CaseView/index.ts
@@ -122,7 +122,7 @@ class CaseView extends BridgeBase {
     this.id = configProps["subheader"];
     this.status = this.thePConn.getValue(".pyStatusWork");
    
-    this.svgCase = Utils.getImageSrc(configProps["icon"], PCore.getAssetLoader().getStaticServerUrl());
+    this.svgCase = Utils.getImageSrc(configProps["icon"], Utils.getSDKStaticContentUrl());
 
 
     // if id has changed, mark flow container needs to init container

--- a/src/components/templates/FieldGroupTemplate/index.ts
+++ b/src/components/templates/FieldGroupTemplate/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import { html, customElement, property } from "@lion/core";
 import { BridgeBase } from "../../../bridge/BridgeBase";
 // NOTE: you need to import ANY component you may render.

--- a/src/components/templates/ListView/index.ts
+++ b/src/components/templates/ListView/index.ts
@@ -89,7 +89,7 @@ class ListView extends BridgeBase {
     
     const componentConfig = this.thePConn.getRawMetadata().config;
     const refList = theConfigProps.referenceList;
-    this.searchIcon = Utils.getImageSrc("search", PCore.getAssetLoader().getStaticServerUrl());
+    this.searchIcon = Utils.getImageSrc("search", Utils.getSDKStaticContentUrl());
     this.getListData();   
   }
 

--- a/src/components/templates/SimpleTable/SimpleTableManual.ts
+++ b/src/components/templates/SimpleTable/SimpleTableManual.ts
@@ -57,7 +57,7 @@ class SimpleTableManual extends BridgeBase {
     //NOTE: Need to bind the callback to 'this' so it has this element's context when it's called.
     this.registerAndSubscribeComponent(this.onStateChange.bind(this));
 
-    this.menuIconOverride = Utils.getImageSrc("trash", PCore.getAssetLoader().getStaticServerUrl());
+    this.menuIconOverride = Utils.getImageSrc("trash", Utils.getSDKStaticContentUrl());
   }
 
   /**

--- a/src/components/widgets/FileUtility/index.ts
+++ b/src/components/widgets/FileUtility/index.ts
@@ -104,7 +104,7 @@ class FileUtility extends BridgeBase {
     this.lu_name = configProps.label;
     this.lu_icon = "paper-clip";
 
-    this.closeSvgIcon = Utils.getImageSrc("times", PCore.getAssetLoader().getStaticServerUrl());
+    this.closeSvgIcon = Utils.getImageSrc("times", Utils.getSDKStaticContentUrl());
 
 
 

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -24,8 +24,6 @@ export class Utils {
   static getSDKStaticContentUrl() {
     const sdkConfigServer = SdkConfigAccess.getSdkConfigServer();
 
-    debugger;
-
     // NOTE: Needs a trailing slash! So add one if not provided
     if (!sdkConfigServer.sdkContentServerUrl.endsWith('/')) {
       sdkConfigServer.sdkContentServerUrl = `${sdkConfigServer.sdkContentServerUrl}/`;

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -2,6 +2,7 @@ import * as dayjs from "dayjs";
 import * as customParseFormat from "dayjs/plugin/customParseFormat";
 import * as localizedFormat from "dayjs/plugin/localizedFormat";
 import * as relativeTime from "dayjs/plugin/relativeTime";
+import { SdkConfigAccess } from './config_access';
 
 dayjs.extend(customParseFormat);
 dayjs.extend(localizedFormat);
@@ -19,6 +20,19 @@ export class Utils {
 
     return sPrefix + this.lastControlID.toString();
   }
+
+  static getSDKStaticContentUrl() {
+    const sdkConfigServer = SdkConfigAccess.getSdkConfigServer();
+
+    debugger;
+
+    // NOTE: Needs a trailing slash! So add one if not provided
+    if (!sdkConfigServer.sdkContentServerUrl.endsWith('/')) {
+      sdkConfigServer.sdkContentServerUrl = `${sdkConfigServer.sdkContentServerUrl}/`;
+    }
+
+    return `${sdkConfigServer.sdkContentServerUrl}constellation/`;
+  }  
 
   static getOptionList(configProps: any, dataObject: any): Array<any> {
     let listType = configProps.listType;


### PR DESCRIPTION
With latest update to 8.8.2 ConstellationJS files to get localization, etc. static content from Infinity static content server, now direct static content expected to be available in the SDK static content server to look there. Implement/use new method: Utils.getSDKStaticContentUrl()