### PR TITLE
Fix Playwright report location

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "copy-index": "shx cp dist/index.html dist/simpleportal.html && shx cp dist/index.html dist/portal.html && shx cp dist/index.html dist/fullportal.html && shx cp dist/index.html dist/embedded.html",
     "test": "node playwright-message.js && playwright test --project=chromium MediaCo/portal MediaCo/embedded",
     "test:headed": "playwright test --headed --project=chromium MediaCo/portal MediaCo/embedded",
-    "test-report": "playwright show-report",
+    "test-report": "playwright show-report tests/playwright-report",
     "build-dev-only": "webpack --mode=development && npm run copy-index",
     "build-prod-only": "webpack --mode=production && npm run copy-index",
     "lint": "run-p -cl lint:*",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -30,7 +30,7 @@ const config = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: [['html', { outputFolder: 'tests/playwright-report' }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */


### PR DESCRIPTION
* Changed the playwright-report location to /tests from root level since Pipeline expects that.