### PR TITLE
fix: console error: Reference is NOT a PConn object

### DIFF
--- a/src/components/ViewContainer/index.ts
+++ b/src/components/ViewContainer/index.ts
@@ -319,7 +319,9 @@ class ViewContainer extends BridgeBase {
       ?displayOnlyFA=${this.displayOnlyFA}
     ></reference-component>`;
 
-    this.renderTemplates.push(theCreatedRefComponent);
+    if (this.createdViewPConn) {
+      this.renderTemplates.push(theCreatedRefComponent);
+    }
     // was: this.renderTemplates.push(theOuterTemplate);
 
     // NOTE: lit-html knows how to render array of lit-html templates!


### PR DESCRIPTION
Added fix to get rid of below console errors by not loading Reference component when PConn is null

![image](https://github.com/user-attachments/assets/014f488e-d943-48e4-ba9c-c8a95be4f473)
